### PR TITLE
Changed formatting in json to be more Zabbix friendly

### DIFF
--- a/lld-disks.py
+++ b/lld-disks.py
@@ -10,4 +10,4 @@ if __name__ == '__main__':
         if line:
 	        data.append({"{#DEVICE}": line, "{#DEVICENAME}": line.replace("/dev/", "")})
 
-    print(json.dumps({"data": data}))
+    print(json.dumps({"data": data}, indent=4))


### PR DESCRIPTION
I had an issue where Zabbix (2.0) didn't like the formatting, and would completely ignore the data. Adding an indent so the JSON pretty prints solves the issue.
