### PR TITLE
Replace all subprocess spawning with pure python

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ With this template you can collect different disk statistics.
 
 Installation
 ------------
-To install, copy `userparameter_diskstats.conf` to /etc/zabbix/zabbix_agentd.d/userparameter_diskstats.conf and `lld-disks.py` to /var/lib/zabbix/scripts/lld-disks.py.
-If /var/lib/zabbix/scripts does't exists, create it: ```sudo mkdir /var/lib/zabbix/scripts -p && sudo chown zabbix:zabbix /var/lib/zabbix -R```
+To install, copy `userparameter_diskstats.conf` to /etc/zabbix/zabbix_agentd.d/userparameter_diskstats.conf and `lld-disks.py` to `/usr/local/bin/lld-disks.py`.
+Do not forget to mark it executable.
+
 `userparameter_diskstats.conf` is user parameters for Zabbix.
 `lld-disks.py` is low level discovery script for enumerating disks of your system.
 
@@ -18,7 +19,8 @@ After that restart zabbix-agent
 Go to Zabbix's web interface, Configuration->Templates and import `Template Disk Performance.xml`.
 After that you should be able to monitor disk activity for all your disks.
 
-Low level discovery won't list your RAID devices, so some tuning may be required.
+Low level discovery will list your RAID devices, and LVM volumes, but LVM
+volumes will be mapped with their device-mapper ID, not the pretty names.
 
 Using without User Parameters
 -----------------------------

--- a/lld-disks.py
+++ b/lld-disks.py
@@ -1,14 +1,12 @@
 #!/usr/bin/python
-
+import os
 import json
-import subprocess
 
-if __name__ == '__main__':
-    process = subprocess.Popen("cat /proc/diskstats | awk '{print $3}' | grep -v 'ram\|loop\|sr'", shell=True, stdout=subprocess.PIPE)
-    output = process.communicate()[0]
-    data = list()
-    for line in output.split("\n"):
-        if line:
-            data.append({"{#DEVICE}": line, "{#DEVICENAME}": line.replace("/dev/", "")})
-
+if __name__ == "__main__":
+    # Iterate over all block devices, but ignore them if they are in the
+    # skippable set
+    skippable = ("sr", "loop", "ram")
+    devices = (device for device in os.listdir("/sys/class/block")
+               if not any(ignore in device for ignore in skippable))
+    data = [{"{#DEVICENAME}": device} for device in devices]
     print(json.dumps({"data": data}, indent=4))

--- a/userparameter_diskstats.conf
+++ b/userparameter_diskstats.conf
@@ -1,4 +1,4 @@
-UserParameter=custom.vfs.discover_disks,python /var/lib/zabbix/scripts/lld-disks.py
+UserParameter=custom.vfs.discover_disks,/usr/local/bin/lld-disks.py
 
 UserParameter=custom.vfs.dev.read.ops[*],awk -e '{print $$1}' /sys/class/block/$1/stat
 UserParameter=custom.vfs.dev.read.merged[*],awk -e '{print $$2}' /sys/class/block/$1/stat

--- a/userparameter_diskstats.conf
+++ b/userparameter_diskstats.conf
@@ -1,14 +1,13 @@
-
 UserParameter=custom.vfs.discover_disks,python /var/lib/zabbix/scripts/lld-disks.py
 
-UserParameter=custom.vfs.dev.read.ops[*],grep -m 1 $1 /proc/diskstats         | awk '{print $$4}'
-UserParameter=custom.vfs.dev.read.merged[*],grep -m 1 $1 /proc/diskstats      | awk '{print $$5}'
-UserParameter=custom.vfs.dev.read.sectors[*],grep -m 1 $1 /proc/diskstats     | awk '{print $$6}'
-UserParameter=custom.vfs.dev.read.ms[*],grep -m 1 $1 /proc/diskstats          | awk '{print $$7}'
-UserParameter=custom.vfs.dev.write.ops[*],grep -m 1 $1 /proc/diskstats        | awk '{print $$8}'
-UserParameter=custom.vfs.dev.write.merged[*],grep -m 1 $1 /proc/diskstats     | awk '{print $$9}'
-UserParameter=custom.vfs.dev.write.sectors[*],grep -m 1 $1 /proc/diskstats    | awk '{print $$10}'
-UserParameter=custom.vfs.dev.write.ms[*],grep -m 1 $1 /proc/diskstats         | awk '{print $$11}'
-UserParameter=custom.vfs.dev.io.active[*],grep -m 1 $1 /proc/diskstats        | awk '{print $$12}'
-UserParameter=custom.vfs.dev.io.ms[*],grep -m 1 $1 /proc/diskstats            | awk '{print $$13}'
-UserParameter=custom.vfs.dev.weight.io.ms[*],grep -m 1 $1 /proc/diskstats     | awk '{print $$14}'
+UserParameter=custom.vfs.dev.read.ops[*],awk -e '{print $$1}' /sys/class/block/$1/stat
+UserParameter=custom.vfs.dev.read.merged[*],awk -e '{print $$2}' /sys/class/block/$1/stat
+UserParameter=custom.vfs.dev.read.sectors[*],awk -e '{print $$3}' /sys/class/block/$1/stat
+UserParameter=custom.vfs.dev.read.ms[*],awk -e '{print $$4}' /sys/class/block/$1/stat
+UserParameter=custom.vfs.dev.write.ops[*],awk -e '{print $$5}' /sys/class/block/$1/stat
+UserParameter=custom.vfs.dev.write.merged[*],awk -e '{print $$6}' /sys/class/block/$1/stat
+UserParameter=custom.vfs.dev.write.sectors[*],awk -e '{print $$7}' /sys/class/block/$1/stat
+UserParameter=custom.vfs.dev.write.ms[*],awk -e '{print $$8}' /sys/class/block/$1/stat
+UserParameter=custom.vfs.dev.io.active[*],awk -e '{print $$9}' /sys/class/block/$1/stat
+UserParameter=custom.vfs.dev.io.ms[*],awk -e '{print $$10}' /sys/class/block/$1/stat
+UserParameter=custom.vfs.dev.weight.io.ms[*],awk -e '{print $$11}' /sys/class/block/$1/stat


### PR DESCRIPTION
And get rid of the silly grep from the zabbix overhead too. Implemented using
awk rather than cut as the stat file may contain multiple spaces.

Tested on:
     Python2.6 / CentOS 6
     Python2.7 / CentOS 7
     Python2.7 / Fedora 23
     Python3  /  Fedora 23